### PR TITLE
Fix anchor scroll overshoot

### DIFF
--- a/index.html
+++ b/index.html
@@ -220,7 +220,7 @@
             </section>
 
             {/* SERVICES */}
-            <section id="services" className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16">
+            <section id="services" className="scroll-mt-24 mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16">
               <div className="flex items-end justify-between gap-6 flex-wrap">
                 <h2 className="font-heading tracking-[0.08em] text-3xl">Servicii</h2>
               </div>
@@ -245,7 +245,7 @@
             </section>
 
             {/* SOLUTIONS */}
-            <section id="solutions" className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16">
+            <section id="solutions" className="scroll-mt-24 mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16">
               <div className="rounded-3xl border border-white/10 bg-[#0b0b0b] p-8 md:p-12">
                 <div className="grid md:grid-cols-2 gap-10 items-center">
                   <div>
@@ -278,7 +278,7 @@
             </section>
 
             {/* WORK */}
-            <section id="work" className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16">
+            <section id="work" className="scroll-mt-24 mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16">
               <h2 className="font-heading tracking-[0.08em] text-3xl">Proiecte</h2>
               <p className="mt-3 font-body text-white/70 max-w-prose">Selecție de proiecte reprezentative. Înlocuiește aceste carduri cu studii de caz reale.</p>
               <div className="mt-8 grid md:grid-cols-3 gap-6">
@@ -317,7 +317,7 @@
             </section>
 
             {/* ABOUT */}
-            <section id="about" className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16">
+            <section id="about" className="scroll-mt-24 mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16">
               <div className="grid md:grid-cols-2 gap-10 items-center">
                 <div>
                   <h2 className="font-heading tracking-[0.08em] text-3xl">Despre Stollix</h2>
@@ -345,7 +345,7 @@
             </section>
 
             {/* CONTACT */}
-            <section id="contact" className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16">
+            <section id="contact" className="scroll-mt-24 mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16">
               <div className="rounded-3xl border border:white/10 overflow-hidden">
                 <div className="grid md:grid-cols-2">
                   <div className="p-8 md:p-12 bg-[#0b0b0b]">


### PR DESCRIPTION
## Summary
- ensure in-page navigation doesn't scroll past section headers by adding `scroll-mt-24`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68bedbf541108324b173cde2e66e71e4