### PR TITLE
feat: update contact section border color and reduce scroll overshoot

### DIFF
--- a/index.html
+++ b/index.html
@@ -220,7 +220,7 @@
             </section>
 
             {/* SERVICES */}
-            <section id="services" className="scroll-mt-24 mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16">
+            <section id="services" className="scroll-mt-16 mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16">
               <div className="flex items-end justify-between gap-6 flex-wrap">
                 <h2 className="font-heading tracking-[0.08em] text-3xl">Servicii</h2>
               </div>
@@ -245,7 +245,7 @@
             </section>
 
             {/* SOLUTIONS */}
-            <section id="solutions" className="scroll-mt-24 mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16">
+            <section id="solutions" className="scroll-mt-16 mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16">
               <div className="rounded-3xl border border-white/10 bg-[#0b0b0b] p-8 md:p-12">
                 <div className="grid md:grid-cols-2 gap-10 items-center">
                   <div>
@@ -278,7 +278,7 @@
             </section>
 
             {/* WORK */}
-            <section id="work" className="scroll-mt-24 mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16">
+            <section id="work" className="scroll-mt-16 mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16">
               <h2 className="font-heading tracking-[0.08em] text-3xl">Proiecte</h2>
               <p className="mt-3 font-body text-white/70 max-w-prose">Selecție de proiecte reprezentative. Înlocuiește aceste carduri cu studii de caz reale.</p>
               <div className="mt-8 grid md:grid-cols-3 gap-6">
@@ -317,7 +317,7 @@
             </section>
 
             {/* ABOUT */}
-            <section id="about" className="scroll-mt-24 mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16">
+            <section id="about" className="scroll-mt-16 mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16">
               <div className="grid md:grid-cols-2 gap-10 items-center">
                 <div>
                   <h2 className="font-heading tracking-[0.08em] text-3xl">Despre Stollix</h2>
@@ -326,11 +326,11 @@
                   </p>
                   <dl className="mt-6 grid grid-cols-2 gap-4">
                     <div className="rounded-2xl border border-white/10 bg-white/[0.02] p-5">
-                      <dt className="text-xs text:white/60">Ani experiență</dt>
+                      <dt className="text-xs text-white/60">Ani experiență</dt>
                       <dd className="font-heading text-2xl tracking-wide" style={{ color: 'var(--stx-secondary400)' }}>10+</dd>
                     </div>
                     <div className="rounded-2xl border border-white/10 bg-white/[0.02] p-5">
-                      <dt className="text-xs text:white/60">Proiecte livrate</dt>
+                      <dt className="text-xs text-white/60">Proiecte livrate</dt>
                       <dd className="font-heading text-2xl tracking-wide" style={{ color: 'var(--stx-accent)' }}>50+</dd>
                     </div>
                   </dl>
@@ -345,8 +345,8 @@
             </section>
 
             {/* CONTACT */}
-            <section id="contact" className="scroll-mt-24 mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16">
-              <div className="rounded-3xl border border:white/10 overflow-hidden">
+            <section id="contact" className="scroll-mt-16 mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16">
+              <div className="rounded-3xl border border-[#9F77FF] overflow-hidden">
                 <div className="grid md:grid-cols-2">
                   <div className="p-8 md:p-12 bg-[#0b0b0b]">
                     <h2 className="font-heading tracking-[0.08em] text-3xl">Hai să lucrăm împreună</h2>
@@ -360,16 +360,16 @@
                   </div>
                   <form className="p-8 md:p-12 space-y-5 bg-white/[0.02]" onSubmit={(e)=>e.preventDefault()}>
                     <div>
-                      <label className="block text-sm text:white/70 mb-2">Nume</label>
+                      <label className="block text-sm text-white/70 mb-2">Nume</label>
                       <input className="w-full bg-transparent rounded-xl border border-white/10 px-4 py-3 outline-none focus:border-white/30" placeholder="Numele tău" required />
                     </div>
                     <div>
-                      <label className="block text-sm text:white/70 mb-2">Email</label>
-                      <input type="email" className="w-full bg-transparent rounded-xl border border:white/10 px-4 py-3 outline-none focus:border:white/30" placeholder="you@company.com" required />
+                      <label className="block text-sm text-white/70 mb-2">Email</label>
+                      <input type="email" className="w-full bg-transparent rounded-xl border border-white/10 px-4 py-3 outline-none focus:border-white/30" placeholder="you@company.com" required />
                     </div>
                     <div>
-                      <label className="block text-sm text:white/70 mb-2">Mesaj</label>
-                      <textarea className="w-full bg-transparent rounded-xl border border:white/10 px-4 py-3 outline-none focus:border:white/30" rows="4" placeholder="Detalii proiect, obiective, deadline…" required></textarea>
+                      <label className="block text-sm text-white/70 mb-2">Mesaj</label>
+                      <textarea className="w-full bg-transparent rounded-xl border border-white/10 px-4 py-3 outline-none focus:border-white/30" rows="4" placeholder="Detalii proiect, obiective, deadline…" required></textarea>
                     </div>
                     <button className="px-6 py-3 rounded-2xl text-[#080808] font-semibold brand-gradient">Trimite</button>
                   </form>


### PR DESCRIPTION
## Summary
- switch contact section container to #9F77FF border while keeping form fields white
- reduce anchor scroll offset to 16 across major sections
- correct label text color classes to use proper Tailwind syntax

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68bede7fcb3483249159ffa27e23cde6