### PR TITLE
feat: add scroll animations to sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,9 @@
 
     <!-- Fonts from your component -->
     <link href="https://fonts.googleapis.com/css2?family=Onest:wght@300;400;500;600;700&family=SUSE:wght@800&display=swap" rel="stylesheet" />
+
+    <!-- AOS animations -->
+    <link rel="stylesheet" href="https://unpkg.com/aos@2.3.1/dist/aos.css" />
   </head>
   <body class="bg-[#080808] text-[#F8F8F8] antialiased">
     <div id="root"></div>
@@ -25,13 +28,20 @@
     <!-- Babel to transpile JSX (fine for demos/Pages; for production, use Vite – see option B) -->
     <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
 
+    <!-- AOS library -->
+    <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
+
     <!-- Your component, unchanged, pasted here -->
     <script type="text/babel">
-      const { useState } = React;
+      const { useState, useEffect } = React;
 
       function StollixSite() {
         const [menuOpen, setMenuOpen] = useState(false);
         const [isClosing, setIsClosing] = useState(false);
+
+        useEffect(() => {
+          AOS.init({ once: true });
+        }, []);
 
         return (
           <div className="min-h-screen bg-[#080808] text-[#F8F8F8] antialiased">
@@ -160,7 +170,7 @@
             </header>
 
             {/* HERO */}
-            <section className="relative overflow-hidden">
+            <section className="relative overflow-hidden" data-aos="fade-up">
               <div className="pointer-events-none absolute -top-24 -left-24 h-64 w-64 rounded-full blur-3xl opacity-30 brand-gradient" />
               <div className="pointer-events-none absolute -bottom-20 -right-24 h-72 w-72 rounded-full blur-3xl opacity-30 brand-gradient" />
 
@@ -220,7 +230,7 @@
             </section>
 
             {/* SERVICES */}
-            <section id="services" className="scroll-mt-16 mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16">
+            <section id="services" className="scroll-mt-16 mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16" data-aos="fade-up">
               <div className="flex items-end justify-between gap-6 flex-wrap">
                 <h2 className="font-heading tracking-[0.08em] text-3xl">Servicii</h2>
               </div>
@@ -230,7 +240,7 @@
                   { title: 'UX/UI & Brand', desc: 'Experiențe moderne aliniate identității vizuale Stollix.', badge: 'Modern' },
                   { title: 'Automatizări & AI', desc: 'Integrare AI, RPA și pipeline-uri care economisesc timp.', badge: 'Eficient' },
                 ].map((c, i) => (
-                  <article key={i} className="group rounded-2xl border border-white/10 p-6 bg-white/[0.02] hover:bg-white/[0.04] transition-colors">
+                  <article key={i} data-aos="fade-up" data-aos-delay={i * 100} className="group rounded-2xl border border-white/10 p-6 bg-white/[0.02] hover:bg-white/[0.04] transition-colors">
                     <div className="flex items-center justify-between">
                       <span className="text-xs tracking-widest uppercase px-3 py-1 rounded-full bg-white/5 border border-white/10">{c.badge}</span>
                       <svg viewBox="0 0 24 24" className="h-5 w-5 opacity-60 group-hover:opacity-100" fill="none" stroke="currentColor" strokeWidth="2">
@@ -245,7 +255,7 @@
             </section>
 
             {/* SOLUTIONS */}
-            <section id="solutions" className="scroll-mt-16 mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16">
+            <section id="solutions" className="scroll-mt-16 mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16" data-aos="fade-up">
               <div className="rounded-3xl border border-white/10 bg-[#0b0b0b] p-8 md:p-12">
                 <div className="grid md:grid-cols-2 gap-10 items-center">
                   <div>
@@ -267,7 +277,7 @@
                   </div>
                   <div className="grid sm:grid-cols-2 gap-4">
                     {['Performanță A+','Accesibilitate','SEO','Securitate'].map((kpi, i) => (
-                      <div key={kpi} className="rounded-2xl border border-white/10 bg-white/[0.02] p-6">
+                      <div key={kpi} data-aos="fade-up" data-aos-delay={i * 100} className="rounded-2xl border border-white/10 bg-white/[0.02] p-6">
                         <p className="text-sm text-white/60">{kpi}</p>
                         <p className="mt-3 font-heading text-3xl tracking-wide" style={{ color: i % 2 ? 'var(--stx-accent)' : 'var(--stx-secondary400)' }}>Top 1%</p>
                       </div>
@@ -278,12 +288,12 @@
             </section>
 
             {/* WORK */}
-            <section id="work" className="scroll-mt-16 mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16">
+            <section id="work" className="scroll-mt-16 mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16" data-aos="fade-up">
               <h2 className="font-heading tracking-[0.08em] text-3xl">Proiecte</h2>
               <p className="mt-3 font-body text-white/70 max-w-prose">Selecție de proiecte reprezentative. Înlocuiește aceste carduri cu studii de caz reale.</p>
               <div className="mt-8 grid md:grid-cols-3 gap-6">
                 {[1,2,3].map((n)=> (
-                  <figure key={n} className="group overflow-hidden rounded-2xl border border-white/10 bg-white/[0.02]">
+                  <figure key={n} data-aos="fade-up" data-aos-delay={n * 100} className="group overflow-hidden rounded-2xl border border-white/10 bg-white/[0.02]">
                     <div className="aspect-[4/3] relative">
                       <div className="absolute inset-0 brand-gradient opacity-20 group-hover:opacity-30 transition-opacity" />
                       <div className="absolute inset-0 grid place-items-center">
@@ -317,7 +327,7 @@
             </section>
 
             {/* ABOUT */}
-            <section id="about" className="scroll-mt-16 mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16">
+            <section id="about" className="scroll-mt-16 mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16" data-aos="fade-up">
               <div className="grid md:grid-cols-2 gap-10 items-center">
                 <div>
                   <h2 className="font-heading tracking-[0.08em] text-3xl">Despre Stollix</h2>
@@ -345,7 +355,7 @@
             </section>
 
             {/* CONTACT */}
-            <section id="contact" className="scroll-mt-16 mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16">
+            <section id="contact" className="scroll-mt-16 mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16" data-aos="fade-up">
               <div className="rounded-3xl border border-[#9F77FF] overflow-hidden">
                 <div className="grid md:grid-cols-2">
                   <div className="p-8 md:p-12 bg-[#0b0b0b]">
@@ -361,15 +371,15 @@
                   <form className="p-8 md:p-12 space-y-5 bg-white/[0.02]" onSubmit={(e)=>e.preventDefault()}>
                     <div>
                       <label className="block text-sm text-white/70 mb-2">Nume</label>
-                      <input className="w-full bg-transparent rounded-xl border border-white/10 px-4 py-3 outline-none focus:border-white/30" placeholder="Numele tău" required />
+                      <input className="w-full bg-transparent rounded-xl border border-white/50 px-4 py-3 outline-none focus:border-white/50" placeholder="Numele tău" required />
                     </div>
                     <div>
                       <label className="block text-sm text-white/70 mb-2">Email</label>
-                      <input type="email" className="w-full bg-transparent rounded-xl border border-white/10 px-4 py-3 outline-none focus:border-white/30" placeholder="you@company.com" required />
+                      <input type="email" className="w-full bg-transparent rounded-xl border border-white/50 px-4 py-3 outline-none focus:border-white/50" placeholder="you@company.com" required />
                     </div>
                     <div>
                       <label className="block text-sm text-white/70 mb-2">Mesaj</label>
-                      <textarea className="w-full bg-transparent rounded-xl border border-white/10 px-4 py-3 outline-none focus:border-white/30" rows="4" placeholder="Detalii proiect, obiective, deadline…" required></textarea>
+                      <textarea className="w-full bg-transparent rounded-xl border border-white/50 px-4 py-3 outline-none focus:border-white/50" rows="4" placeholder="Detalii proiect, obiective, deadline…" required></textarea>
                     </div>
                     <button className="px-6 py-3 rounded-2xl text-[#080808] font-semibold brand-gradient">Trimite</button>
                   </form>


### PR DESCRIPTION
## Summary
- load AOS library and initialize on mount
- animate sections and cards on scroll with fade-up effects
- set form input borders to 50% opacity for better visibility

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68bee3f5a5a0832487fe3b379b7d5fe1